### PR TITLE
Make buildable with Java 13

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -102,7 +102,7 @@ public final class BuildCommit {
     <!-- Compile the java code from ${src} into ${build} -->
     <javac srcdir="${quakeinjector.src}" destdir="${quakeinjector.build}" 
 		   debug="on" debuglevel="lines,vars,source"
-		   source="1.6" fork="true">
+		   fork="true">
 	  <classpath refid="quakeinjector.class.path"/>
 <!--	  <compilerarg value="-Xlint"/> -->
 	  <compilerarg value="-Xlint:unchecked"/>


### PR DESCRIPTION
TLDR: This pull request gets Quake Injector building and running with Java 13.

Anyway...

I saw that https://github.com/hrehfeld/QuakeInjector/pull/118 was merged, so I thought I'd test to see how Quake Injector builds with later versions of Java.

First, it's always built fine with Java SE **1.8.0_241**, and it continues to do so:

`Buildfile: /home/dugan/Documents/QuakeInjector/build.xml`

`quakeinjector.init:`

`getversion:`

`dumpversion:`

`compile:`
    `[javac] /home/dugan/Documents/QuakeInjector/build.xml:105: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds`
    `[javac] Compiling 68 source files to /home/dugan/Documents/QuakeInjector/bin`
    `[javac] warning: [options] bootstrap class path not set in conjunction with -source 1.6`
    `[javac] /home/dugan/Documents/QuakeInjector/src/de/haukerehfeld/quakeinjector/PackageInteractionPanel.java:518: warning: [unchecked] unchecked call to addItem(E) as a member of the raw type JComboBox`
    `[javac] 			startmaps.addItem(startmap);`
    `[javac] 			                ^`
    `[javac]   where E is a type-variable:`
    `[javac]     E extends Object declared in class JComboBox`
    `[javac] 2 warnings`

`BUILD SUCCESSFUL`
`Total time: 1 second`

Testing with Java SE **11.0.6**, I got a warning about the "-source" option, but it built fine:

`Buildfile: /home/dugan/Documents/QuakeInjector/build.xml`

`quakeinjector.init:`

`getversion:`

`dumpversion:`

`compile:`
    `[javac] /home/dugan/Documents/QuakeInjector/build.xml:105: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds`
    `[javac] Compiling 68 source files to /home/dugan/Documents/QuakeInjector/bin`
    `[javac] warning: [options] bootstrap class path not set in conjunction with -source 6`
    `[javac] warning: [options] source value 6 is obsolete and will be removed in a future release`
    `[javac] warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.`
    `[javac] /home/dugan/Documents/QuakeInjector/src/de/haukerehfeld/quakeinjector/PackageInteractionPanel.java:518: warning: [unchecked] unchecked call to addItem(E) as a member of the raw type JComboBox`
    `[javac] 			startmaps.addItem(startmap);`
    `[javac] 			                ^`
    `[javac]   where E is a type-variable:`
    `[javac]     E extends Object declared in class JComboBox`
    `[javac] /home/dugan/Documents/QuakeInjector/src/de/haukerehfeld/quakeinjector/gui/JPathPanel.java:287: warning: [deprecation] shouldYieldFocus(JComponent) in InputVerifier has been deprecated`
    `[javac] 		public boolean shouldYieldFocus(JComponent input) {`
    `[javac] 		              ^`
    `[javac] 5 warnings`

`BUILD SUCCESSFUL`
`Total time: 1 second`

When I tested with Java SE **13.0.2**, which is the first version that isn't considered such a legacy product that you have to sign into Oracle to download it, the "-source" option outright prevented it from building:

`Buildfile: /home/dugan/Documents/QuakeInjector/build.xml`

`quakeinjector.init:`

`getversion:`

`dumpversion:`

`compile:`
    `[javac] /home/dugan/Documents/QuakeInjector/build.xml:105: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds`
    `[javac] Compiling 68 source files to /home/dugan/Documents/QuakeInjector/bin`
    `[javac] warning: [options] bootstrap class path not set in conjunction with -source 6`
    `[javac] error: Source option 6 is no longer supported. Use 7 or later.`

`BUILD FAILED`
`/home/dugan/Documents/QuakeInjector/build.xml:105: Compile failed; see the compiler error output for details.`

`Total time: 0 seconds`

I tried taking that option out, and then building again with Java 13. It built fine, with the same compiler messages I got when building with Java 8. Ran fine too.

`Buildfile: /home/dugan/Documents/QuakeInjector/build.xml`

`quakeinjector.init:`

`getversion:`

`dumpversion:`

`compile:`
    `[javac] /home/dugan/Documents/QuakeInjector/build.xml:105: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds`
    `[javac] Compiling 68 source files to /home/dugan/Documents/QuakeInjector/bin`
    `[javac] /home/dugan/Documents/QuakeInjector/src/de/haukerehfeld/quakeinjector/PackageInteractionPanel.java:518: warning: [unchecked] unchecked call to addItem(E) as a member of the raw type JComboBox`
    `[javac] 			startmaps.addItem(startmap);`
    `[javac] 			                ^`
    `[javac]   where E is a type-variable:`
    `[javac]     E extends Object declared in class JComboBox`
    `[javac] /home/dugan/Documents/QuakeInjector/src/de/haukerehfeld/quakeinjector/gui/JPathPanel.java:287: warning: [deprecation] shouldYieldFocus(JComponent) in InputVerifier has been deprecated`
    `[javac] 		public boolean shouldYieldFocus(JComponent input) {`
    `[javac] 		              ^`
    `[javac] 2 warnings`

`BUILD SUCCESSFUL`
`Total time: 1 second`