### PR TITLE
Fix Gnome UI Scaling

### DIFF
--- a/src/de/haukerehfeld/quakeinjector/PackageTable.java
+++ b/src/de/haukerehfeld/quakeinjector/PackageTable.java
@@ -19,19 +19,13 @@ along with QuakeInjector.  If not, see <http://www.gnu.org/licenses/>.
 */
 package de.haukerehfeld.quakeinjector;
 
-import java.awt.Dimension;
-import java.awt.Color;
-import java.awt.Component;
+import de.haukerehfeld.quakeinjector.packagelist.model.PackageListModel;
 
-import javax.swing.UIManager;
-
-import javax.swing.JTable;
-import javax.swing.JComponent;
+import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableRowSorter;
-
-import de.haukerehfeld.quakeinjector.packagelist.model.PackageListModel;
+import java.awt.*;
 
 /**
  * @todo check if dependency on de.haukerehfeld.quakeinjector.packagelist.model.PackageListModel is necessary
@@ -43,7 +37,6 @@ public class PackageTable extends JTable {
 	private static final int CELLPADDING = 2;
 
 	private final EmptyBorder border = new EmptyBorder(0, CELLPADDING, 0, CELLPADDING);
-	                                                           
 
 	public PackageTable(PackageListModel maplist) {
 		super(maplist);
@@ -58,6 +51,7 @@ public class PackageTable extends JTable {
 		setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
 		setShowGrid(false);
 		setIntercellSpacing(new Dimension(0, 0));
+		setRowHeight(getFontMetrics(getFont()).getHeight());
 
 		setDefaultRenderer(Package.Rating.class, new PackageListModel.RatingRenderer());		
 	}
@@ -67,7 +61,7 @@ public class PackageTable extends JTable {
      */
 	public Component prepareRenderer(TableCellRenderer renderer, int row, int column) {
 		Component c = super.prepareRenderer(renderer, row, column);
-        if (isCellSelected(row, column) == false) {
+        if (!isCellSelected(row, column)) {
             c.setBackground(colorForRow(row));
             c.setForeground(UIManager.getColor("Table.foreground"));
         } else {


### PR DESCRIPTION
Setting the row height to the default system height ensures the rows can fit 200% scaled text. This doesn't change dynamically, but that seems to work for the use case described in [issue #120](https://github.com/hrehfeld/QuakeInjector/issues/120). The UI could also use some improvement in this case to vertically center the rating.

A picture of this running on my Ubuntu system at 100% scaling:
![image](https://user-images.githubusercontent.com/36193438/91235493-8c343e00-e72d-11ea-9d6e-e5b00681093a.png)

And again at 200%: 
![image](https://user-images.githubusercontent.com/36193438/91235621-d3baca00-e72d-11ea-8b5b-4bdc6695bb77.png)

This behaves the same way on Windows. 