### PR TITLE
Fix Gnome UI Scaling [DUPLICATE]

### DIFF
--- a/src/de/haukerehfeld/quakeinjector/PackageTable.java
+++ b/src/de/haukerehfeld/quakeinjector/PackageTable.java
@@ -58,6 +58,7 @@ public class PackageTable extends JTable {
 		setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
 		setShowGrid(false);
 		setIntercellSpacing(new Dimension(0, 0));
+		setRowHeight(getFontMetrics(getFont()).getHeight());
 
 		setDefaultRenderer(Package.Rating.class, new PackageListModel.RatingRenderer());		
 	}


### PR DESCRIPTION
DUPLICATE OF PR #124

Setting the row height to the default system height ensures the rows can fit 200% scaled text. This doesn't change dynamically, but that seems to work for the use case described in [issue #120](https://github.com/hrehfeld/QuakeInjector/issues/120). The UI could also use some improvement in this case to vertically center the rating. This behaves the same way on Windows. 

A picture of this running on my Ubuntu system at 100% scaling:
![image](https://user-images.githubusercontent.com/36193438/91235493-8c343e00-e72d-11ea-9d6e-e5b00681093a.png)

And again at 200%: 
![image](https://user-images.githubusercontent.com/36193438/91235621-d3baca00-e72d-11ea-8b5b-4bdc6695bb77.png)

Apologies for the duplicate. 