### PR TITLE
use zip64mode for releases

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -200,7 +200,7 @@ public final class BuildCommit {
 
   <target name="release" description="Build jar and zip for release"
      depends="quakeinjector.jar,getversion">
-     <zip destfile="${quakeinjector.release}/quakeinjector-${quakeinjector.buildcommit}.zip">
+     <zip destfile="${quakeinjector.release}/quakeinjector-${quakeinjector.buildcommit}.zip" zip64Mode="always">
        <fileset dir="${quakeinjector.dist}" />
      </zip>
 


### PR DESCRIPTION
Should fix 7z warning about "Headers Error" and thus fix #131

Ref: https://stackoverflow.com/questions/57557842/how-to-resolve-7-zips-warnings-headers-error-from-zip-created-by-ant-build

Untested.