### PR TITLE
Added a check to not reinstall existing maps when using the random map button

### DIFF
--- a/src/de/haukerehfeld/quakeinjector/QuakeInjector.java
+++ b/src/de/haukerehfeld/quakeinjector/QuakeInjector.java
@@ -509,9 +509,9 @@ public class QuakeInjector extends JFrame {
 		for (PackageFileList l: packages) {
 			maps.setInstalled(l);
 		}
-		for (Requirement r: maps) {
+		//for (Requirement r: maps) {
 			//System.out.println(r);
-		}
+		//}
 		
 		maps.notifyChangeListeners();
 
@@ -769,7 +769,10 @@ public class QuakeInjector extends JFrame {
 					// table. Therefore, it has to be converted.
 					int mapTableRowIdx = new Random().nextInt(maplist.getRowCount());
 					int mapListIdx = table.getRowSorter().convertRowIndexToModel(mapTableRowIdx);
-					interactionPanel.install(maplist.getPackage(mapListIdx), false);
+					Package map = maplist.getPackage(mapListIdx);
+					if(!maplist.isPackageInstalled(map))
+						interactionPanel.install(map, false);
+
 					table.setRowSelectionInterval(mapTableRowIdx, mapTableRowIdx);
 					table.scrollRectToVisible(new Rectangle(table.getCellRect(mapTableRowIdx, 0, true)));
 				}
@@ -780,10 +783,8 @@ public class QuakeInjector extends JFrame {
 			}});
 		}
 
-
 		//Create the scroll pane and add the table to it.
 		JScrollPane scrollPane = new JScrollPane(table);
-
 
 		mainPanel.add(scrollPane, new GridBagConstraints() {{
 				anchor = CENTER;
@@ -861,8 +862,6 @@ public class QuakeInjector extends JFrame {
 		splitPane.setMinimumSize(new Dimension(450, 300));
 
 		panel.add(splitPane);
-
-		
 	}
 
 	

--- a/src/de/haukerehfeld/quakeinjector/packagelist/model/PackageListModel.java
+++ b/src/de/haukerehfeld/quakeinjector/packagelist/model/PackageListModel.java
@@ -126,6 +126,10 @@ public class PackageListModel extends AbstractTableModel implements ChangeListen
 		return Column.getColumn(col).getData(info);
 	}
 
+	public boolean isPackageInstalled(Package info){
+		return (boolean) getColumnData(0, info);
+	}
+
     @Override
 	public Class<? extends Object> getColumnClass(int c) {
 		return Column.getColumn(c).getColumnClass();
@@ -135,7 +139,6 @@ public class PackageListModel extends AbstractTableModel implements ChangeListen
     public Object getValueAt(int row, int col) {
         return getColumnData(col, data.get(row));
     }
-
 
     @Override
 	public boolean isCellEditable(int row, int col) {


### PR DESCRIPTION
This relies on the UI showing the map's install status, rather than the installed package itself, but it should fix the issue. Fixes https://github.com/hrehfeld/QuakeInjector/issues/133