### PR TITLE
fix: escape spaces and more in download URLs

### DIFF
--- a/src/main/java/de/haukerehfeld/quakeinjector/Download.java
+++ b/src/main/java/de/haukerehfeld/quakeinjector/Download.java
@@ -24,6 +24,9 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.zip.GZIPInputStream;
@@ -36,15 +39,19 @@ public class Download {
 	private URLConnection connection;
 
 	public static Download create(String urlString) throws IOException {
-		URL url;
+		URL cleanUrl;
 		try {
-			url = new URL(urlString);
+			// URLs with spaces in the path need escaping to %20, not +. We can't use built in URLEncoder
+			URL url= new URL(urlString);
+			URI uri = new URI(url.getProtocol(), url.getUserInfo(), url.getHost(), url.getPort(), url.getPath(), url.getQuery(), url.getRef());
+
+			cleanUrl = new URL(uri.toASCIIString());
 		}
-		catch (java.net.MalformedURLException e) {
+		catch (MalformedURLException | URISyntaxException e) {
 			throw new RuntimeException("Something is wrong with the way we construct URLs: "
 			                           + e.getMessage());
 		}
-		return new Download(url);
+		return new Download(cleanUrl);
 	}
 
 	public Download(URL url) throws IOException {


### PR DESCRIPTION
Fix the download class to handle URLs that need spaces and other special chars to be escaped.

This should fix https://github.com/hrehfeld/QuakeInjector/issues/143 . I did look at some other alternatives, and the suggestion that was made in that issue seems to be the most robust. Here's some more discussion on the subject: https://stackoverflow.com/questions/4737841/urlencoder-not-able-to-translate-space-character

Thanks for making QuakeInjector, it's a really slick way to find new maps!

